### PR TITLE
Shader set uniform

### DIFF
--- a/modules/graphics/include/moon/mrb/helpers.hxx
+++ b/modules/graphics/include/moon/mrb/helpers.hxx
@@ -90,4 +90,15 @@ get_valid_texture(mrb_state *mrb, mrb_value obj)
   return texture;
 }
 
+static inline glm::mat4 moon_rotate(float angle, glm::vec2 origin) {
+  // rotation matrix - rotate the model around specified origin
+  // really ugly, we translate the rotation origin to 0,0, rotate,
+  // then translate back to original position
+  return  glm::translate(glm::rotate(
+        glm::translate(glm::mat4(1.0f), glm::vec3(origin.x, origin.y, 0)),
+        glm::radians(angle),
+        glm::vec3(0, 0, 1)
+        ), glm::vec3(-origin.x, -origin.y, 0));
+}
+
 #endif

--- a/modules/graphics/include/moon/mrb/helpers.hxx
+++ b/modules/graphics/include/moon/mrb/helpers.hxx
@@ -90,15 +90,12 @@ get_valid_texture(mrb_state *mrb, mrb_value obj)
   return texture;
 }
 
-static inline glm::mat4 moon_rotate(float angle, glm::vec2 origin) {
-  // rotation matrix - rotate the model around specified origin
-  // really ugly, we translate the rotation origin to 0,0, rotate,
-  // then translate back to original position
-  return  glm::translate(glm::rotate(
-        glm::translate(glm::mat4(1.0f), glm::vec3(origin.x, origin.y, 0)),
-        glm::radians(angle),
-        glm::vec3(0, 0, 1)
-        ), glm::vec3(-origin.x, -origin.y, 0));
+static inline glm::mat4 moon_rotate(float angle, const glm::vec2 origin) {
+  return glm::translate(glm::rotate(
+    glm::mat4(1.0f),
+    glm::radians(angle),
+    glm::vec3(0, 0, 1)
+  ), glm::vec3(-origin.x, -origin.y, 0));
 }
 
 #endif

--- a/modules/graphics/include/moon/shader.hxx
+++ b/modules/graphics/include/moon/shader.hxx
@@ -21,9 +21,8 @@ namespace Moon {
     Shader(const std::string vertexShader, const std::string fragmentShader);
     ~Shader();
     void   Use();
-    GLuint GetProgram();
-    GLint  GetAttribute(const char *name);
-    GLint  GetUniform(const char *name);
+    GLint  Attribute(const char *name);
+    GLint  Uniform(const char *name);
 
     void SetUniform(const char *name, const GLint v1);
     void SetUniform(const char *name, const GLfloat v1);

--- a/modules/graphics/include/moon/shader.hxx
+++ b/modules/graphics/include/moon/shader.hxx
@@ -25,10 +25,10 @@ namespace Moon {
     GLint  GetAttribute(const char *name);
     GLint  GetUniform(const char *name);
 
-    void SetUniform(const char *name, GLint v1);
-    void SetUniform(const char *name, GLfloat v1);
-    void SetUniform(const char *name, Moon::Vector4 v1);
-    void SetUniform(const char *name, glm::mat4 v1);
+    void SetUniform(const char *name, const GLint v1);
+    void SetUniform(const char *name, const GLfloat v1);
+    void SetUniform(const char *name, const Moon::Vector4 &vec);
+    void SetUniform(const char *name, const glm::mat4 &mat);
   private:
     GLuint  m_program;
     AttributeMap m_attributeList;

--- a/modules/graphics/include/moon/shader.hxx
+++ b/modules/graphics/include/moon/shader.hxx
@@ -8,6 +8,7 @@
 #include "moon/intern.h"
 #include "moon/gl.h"
 #include "moon/glm.h"
+#include "moon/vector4.hxx"
 
 namespace Moon {
   class Shader {
@@ -23,6 +24,11 @@ namespace Moon {
     GLuint GetProgram();
     GLint  GetAttribute(const char *name);
     GLint  GetUniform(const char *name);
+
+    void SetUniform(const char *name, GLint v1);
+    void SetUniform(const char *name, GLfloat v1);
+    void SetUniform(const char *name, Moon::Vector4 v1);
+    void SetUniform(const char *name, glm::mat4 v1);
   private:
     GLuint  m_program;
     AttributeMap m_attributeList;

--- a/modules/graphics/include/moon/vertex_buffer.hxx
+++ b/modules/graphics/include/moon/vertex_buffer.hxx
@@ -14,7 +14,7 @@ namespace Moon {
     VertexBuffer(GLenum usage); // STATIC_DRAW, DYNAMIC_DRAW...
     ~VertexBuffer();
     void Render(GLenum mode);
-    void RenderWithOffset(GLenum mode, const int offset); // adds offset to the indices used (draws vertex at vbo[indice + offset])
+    void Render(GLenum mode, const int offset); // adds offset to the indices used (draws vertex at vbo[indice + offset])
     void PushBack(Vertex v);
     void PushBackVertices(Vertex *v, int vertex_count);
     void PushBackIndices(GLuint i[], int index_count);

--- a/modules/graphics/src/font.cxx
+++ b/modules/graphics/src/font.cxx
@@ -49,9 +49,8 @@ namespace Moon {
     m_font->outline_type = 0;
     m_font->outline_thickness = 0;
     AddText(text, render_ops.color);
+
     shader->Use();
-    glBindTexture(GL_TEXTURE_2D, m_atlas->id);
-    glUniform1i(shader->GetUniform("tex"), /*GL_TEXTURE*/0);
     //model matrix
     glm::mat4 model_matrix = glm::rotate( // rotate it for 180 around the x-axis, because the text was upside down
       glm::translate(render_ops.transform, glm::vec3(x, y + m_font->ascender, z)), // move it to the correct position in the world
@@ -60,7 +59,11 @@ namespace Moon {
     );
     // calculate the ModelViewProjection matrix (faster to do on CPU, once for all vertices instead of per vertex)
     glm::mat4 mvp_matrix = Shader::projection_matrix * Shader::view_matrix * model_matrix;
-    glUniformMatrix4fv(shader->GetUniform("mvp_matrix"), 1, GL_FALSE, glm::value_ptr(mvp_matrix));
+    shader->SetUniform("mvp_matrix", mvp_matrix);
+
+    // Set texture ID
+    glBindTexture(GL_TEXTURE_2D, m_atlas->id);
+    shader->SetUniform("tex", /*GL_TEXTURE*/0);
     m_buffer.Render(GL_TRIANGLES);
     m_buffer.Clear();
   }

--- a/modules/graphics/src/mrb_sprite.cxx
+++ b/modules/graphics/src/mrb_sprite.cxx
@@ -86,18 +86,21 @@ sprite_render(mrb_state *mrb, mrb_value self)
         glm::radians(angle),
         glm::vec3(0, 0, 1)
         ), glm::vec3(-origin.x, -origin.y, 0));
+
   // model matrix - move it to the correct position in the world
   glm::mat4 model_matrix = glm::translate(glm::mat4(1.0f), glm::vec3(x, y, z));
   // calculate the ModelViewProjection matrix (faster to do on CPU, once for all vertices instead of per vertex)
   glm::mat4 mvp_matrix = Moon::Shader::projection_matrix * Moon::Shader::view_matrix * model_matrix * rotation_matrix;
-  glUniformMatrix4fv(shader->GetUniform("mvp_matrix"), 1, GL_FALSE, glm::value_ptr(mvp_matrix));
-  glUniform1f(shader->GetUniform("opacity"), opacity);
-  glUniform4fv(shader->GetUniform("color"), 1, glm::value_ptr(color));
-  glUniform4fv(shader->GetUniform("tone"), 1, glm::value_ptr(tone));
+  shader->SetUniform("mvp_matrix", mvp_matrix);
+
+  shader->SetUniform("opacity", opacity);
+  shader->SetUniform("color",  color);
+  shader->SetUniform("tone", tone);
+
   //Set texture ID
   glActiveTexture(GL_TEXTURE0);
   texture->Bind();
-  glUniform1i(shader->GetUniform("tex"), /*GL_TEXTURE*/0);
+  shader->SetUniform("tex", /*GL_TEXTURE*/0);
   vbo->Render(GL_TRIANGLE_STRIP);
   return self;
 }

--- a/modules/graphics/src/mrb_sprite.cxx
+++ b/modules/graphics/src/mrb_sprite.cxx
@@ -78,15 +78,8 @@ sprite_render(mrb_state *mrb, mrb_value self)
   mrb_get_args(mrb, "fff", &x, &y, &z);
 
   shader->Use();
-  // rotation matrix - rotate the model around specified origin
-  // really ugly, we translate the rotation origin to 0,0, rotate,
-  // then translate back to original position
-  glm::mat4 rotation_matrix = glm::translate(glm::rotate(
-        glm::translate(glm::mat4(1.0f), glm::vec3(origin.x, origin.y, 0)),
-        glm::radians(angle),
-        glm::vec3(0, 0, 1)
-        ), glm::vec3(-origin.x, -origin.y, 0));
 
+  glm::mat4 rotation_matrix = moon_rotate(angle, origin);
   // model matrix - move it to the correct position in the world
   glm::mat4 model_matrix = glm::translate(glm::mat4(1.0f), glm::vec3(x, y, z));
   // calculate the ModelViewProjection matrix (faster to do on CPU, once for all vertices instead of per vertex)

--- a/modules/graphics/src/mrb_spritesheet.cxx
+++ b/modules/graphics/src/mrb_spritesheet.cxx
@@ -125,7 +125,7 @@ render(mrb_state *mrb, mrb_value self, const glm::vec3 position,
   texture->Bind();
   shader->SetUniform("tex", /*GL_TEXTURE*/0);
 
-  vbo->RenderWithOffset(GL_TRIANGLE_STRIP, offset);
+  vbo->Render(GL_TRIANGLE_STRIP, offset);
 };
 
 /*

--- a/modules/graphics/src/mrb_spritesheet.cxx
+++ b/modules/graphics/src/mrb_spritesheet.cxx
@@ -108,14 +108,9 @@ render(mrb_state *mrb, mrb_value self, const glm::vec3 position,
 
   shader->Use();
 
+  glm::mat4 rotation_matrix = moon_rotate(render_ops.angle, render_ops.origin);
   //model matrix - move it to the correct position in the world
-  Moon::Vector2 origin = render_ops.origin;
   glm::mat4 model_matrix = glm::translate(render_ops.transform, position);
-  glm::mat4 rotation_matrix = glm::translate(glm::rotate(
-        glm::translate(glm::mat4(1.0f), glm::vec3(origin.x, origin.y, 0)),
-        glm::radians(render_ops.angle),
-        glm::vec3(0, 0, 1)
-        ), glm::vec3(-origin.x, -origin.y, 0));
 
   // calculate the ModelViewProjection matrix (faster to do on CPU, once for all vertices instead of per vertex)
   glm::mat4 mvp_matrix = Moon::Shader::projection_matrix * Moon::Shader::view_matrix * model_matrix * rotation_matrix;

--- a/modules/graphics/src/mrb_spritesheet.cxx
+++ b/modules/graphics/src/mrb_spritesheet.cxx
@@ -119,16 +119,16 @@ render(mrb_state *mrb, mrb_value self, const glm::vec3 position,
 
   // calculate the ModelViewProjection matrix (faster to do on CPU, once for all vertices instead of per vertex)
   glm::mat4 mvp_matrix = Moon::Shader::projection_matrix * Moon::Shader::view_matrix * model_matrix * rotation_matrix;
-  glUniformMatrix4fv(shader->GetUniform("mvp_matrix"), 1, GL_FALSE, glm::value_ptr(mvp_matrix));
+  shader->SetUniform("mvp_matrix", mvp_matrix);
 
-  glUniform1f(shader->GetUniform("opacity"), render_ops.opacity);
-  glUniform4fv(shader->GetUniform("tone"), 1, glm::value_ptr(render_ops.tone));
-  glUniform4fv(shader->GetUniform("color"), 1, glm::value_ptr(render_ops.color));
+  shader->SetUniform("opacity", render_ops.opacity);
+  shader->SetUniform("color", render_ops.color);
+  shader->SetUniform("tone", render_ops.tone);
 
   //Set texture ID
   glActiveTexture(GL_TEXTURE0);
   texture->Bind();
-  glUniform1i(shader->GetUniform("tex"), /*GL_TEXTURE*/0);
+  shader->SetUniform("tex", /*GL_TEXTURE*/0);
 
   vbo->RenderWithOffset(GL_TRIANGLE_STRIP, offset);
 };

--- a/modules/graphics/src/mrb_vertex_buffer.cxx
+++ b/modules/graphics/src/mrb_vertex_buffer.cxx
@@ -49,7 +49,7 @@ vbo_render(mrb_state *mrb, mrb_value self)
   offset = 0;
   mrb_get_args(mrb, "i|i", &mode, &offset);
 
-  get_vbo(mrb, self)->RenderWithOffset(mode, offset);
+  get_vbo(mrb, self)->Render(mode, offset);
   return self;
 }
 

--- a/modules/graphics/src/shader.cxx
+++ b/modules/graphics/src/shader.cxx
@@ -115,7 +115,7 @@ namespace Moon {
     return uniform;
   }
 
-  GLint Shader::GetAttribute(const char *name) {
+  GLint Shader::Attribute(const char *name) {
     assert(m_program);
     assert(name);
     AttributeMap::iterator iter = m_attributeList.find(name);
@@ -126,7 +126,7 @@ namespace Moon {
     }
   }
 
-  GLint Shader::GetUniform(const char *name) {
+  GLint Shader::Uniform(const char *name) {
     assert(m_program);
     assert(name);
     AttributeMap::iterator iter = m_uniformLocationList.find(name);
@@ -138,23 +138,19 @@ namespace Moon {
   }
 
   void Shader::SetUniform(const char *name, const GLint v1) {
-    glUniform1i(GetUniform(name), v1);
+    glUniform1i(Uniform(name), v1);
   }
 
   void Shader::SetUniform(const char *name, const GLfloat v1) {
-    glUniform1f(GetUniform(name), v1);
+    glUniform1f(Uniform(name), v1);
   }
 
   void Shader::SetUniform(const char *name, const Moon::Vector4 &vec) {
-    glUniform4fv(GetUniform(name), 1, glm::value_ptr(vec));
+    glUniform4fv(Uniform(name), 1, glm::value_ptr(vec));
   }
 
   void Shader::SetUniform(const char *name, const glm::mat4 &mat) {
-    glUniformMatrix4fv(GetUniform(name), 1, GL_FALSE, glm::value_ptr(mat));
-  }
-
-  GLuint Shader::GetProgram() {
-    return m_program;
+    glUniformMatrix4fv(Uniform(name), 1, GL_FALSE, glm::value_ptr(mat));
   }
 
   void Shader::Use() {

--- a/modules/graphics/src/shader.cxx
+++ b/modules/graphics/src/shader.cxx
@@ -137,6 +137,22 @@ namespace Moon {
     }
   }
 
+  void Shader::SetUniform(const char *name, GLint v1) {
+    glUniform1i(GetUniform(name), v1);
+  }
+
+  void Shader::SetUniform(const char *name, GLfloat v1) {
+    glUniform1f(GetUniform(name), v1);
+  }
+
+  void Shader::SetUniform(const char *name, Moon::Vector4 v1) {
+    glUniform4fv(GetUniform(name), 1, glm::value_ptr(v1));
+  }
+
+  void Shader::SetUniform(const char *name, glm::mat4 v1) {
+    glUniformMatrix4fv(GetUniform(name), 1, GL_FALSE, glm::value_ptr(v1));
+  }
+
   GLuint Shader::GetProgram() {
     return m_program;
   }

--- a/modules/graphics/src/shader.cxx
+++ b/modules/graphics/src/shader.cxx
@@ -137,20 +137,20 @@ namespace Moon {
     }
   }
 
-  void Shader::SetUniform(const char *name, GLint v1) {
+  void Shader::SetUniform(const char *name, const GLint v1) {
     glUniform1i(GetUniform(name), v1);
   }
 
-  void Shader::SetUniform(const char *name, GLfloat v1) {
+  void Shader::SetUniform(const char *name, const GLfloat v1) {
     glUniform1f(GetUniform(name), v1);
   }
 
-  void Shader::SetUniform(const char *name, Moon::Vector4 v1) {
-    glUniform4fv(GetUniform(name), 1, glm::value_ptr(v1));
+  void Shader::SetUniform(const char *name, const Moon::Vector4 &vec) {
+    glUniform4fv(GetUniform(name), 1, glm::value_ptr(vec));
   }
 
-  void Shader::SetUniform(const char *name, glm::mat4 v1) {
-    glUniformMatrix4fv(GetUniform(name), 1, GL_FALSE, glm::value_ptr(v1));
+  void Shader::SetUniform(const char *name, const glm::mat4 &mat) {
+    glUniformMatrix4fv(GetUniform(name), 1, GL_FALSE, glm::value_ptr(mat));
   }
 
   GLuint Shader::GetProgram() {

--- a/modules/graphics/src/vertex_buffer.cxx
+++ b/modules/graphics/src/vertex_buffer.cxx
@@ -112,10 +112,10 @@ namespace Moon {
     glBindVertexArray(m_vao_id);
     glDrawElements(mode, m_indices.size(), GL_UNSIGNED_INT, NULL);
     glBindVertexArray(0);*/
-    RenderWithOffset(mode, 0);
+    Render(mode, 0);
   }
 
-  void VertexBuffer::RenderWithOffset(GLenum mode, const int offset) {
+  void VertexBuffer::Render(GLenum mode, const int offset) {
     if (m_dirty) Upload(); // update the VBO and IBO if dirty
     glBindVertexArray(m_vao_id);
     glDrawElementsBaseVertex(mode, m_indices.size(), GL_UNSIGNED_INT, NULL, offset);


### PR DESCRIPTION
General refactor to simplify the usage of shaders, and to prepare the code for mruby integration (setting uniforms from mruby). Code is now also looking more general, sprite and spritesheet now pretty much share the render function.

@IceDragon200 please thoroughly review this, especially regarding the function arguments, I'd like to use pointers or references for these so that we avoid doing data copies. 